### PR TITLE
Återbalansera händelser i spelet

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -281,7 +281,7 @@
   - type: StationEvent
     earliestStart: 15
     minimumPlayers: 15
-    weight: 7
+    weight: 9
     duration: 240
   - type: KudzuGrowthRule
 
@@ -290,7 +290,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    weight: 5
+    weight: 3
     startAnnouncement: station-event-power-grid-check-start-announcement
     endAnnouncement: station-event-power-grid-check-end-announcement
     startAudio:
@@ -306,7 +306,7 @@
   id: SolarFlare
   components:
   - type: StationEvent
-    weight: 8
+    weight: 6
     startAnnouncement: station-event-solar-flare-start-announcement
     endAnnouncement: station-event-solar-flare-end-announcement
     startAudio: # Corvax-Announcements
@@ -357,7 +357,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
+    weight: 4
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -378,7 +378,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
+    weight: 4
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -399,7 +399,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
+    weight: 4
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -467,7 +467,7 @@
   components:
   - type: StationEvent
     earliestStart: 35
-    weight: 5.5
+    weight: 4.5
     minimumPlayers: 20
     duration: 1
   - type: RuleGrids
@@ -502,7 +502,7 @@
   components:
   - type: StationEvent
     earliestStart: 30
-    weight: 8
+    weight: 7
     minimumPlayers: 15
     maxOccurrences: 1 # can only happen once per round
     startAnnouncement: station-event-communication-interception

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -106,7 +106,7 @@
   id: GameRuleSpaceDustMinor
   components:
   - type: StationEvent
-    weight: 44
+    weight: 26
     earliestStart: 2
     minimumPlayers: 0
   - type: MeteorSwarm
@@ -127,7 +127,7 @@
   id: GameRuleSpaceDustMajor
   components:
   - type: StationEvent
-    weight: 22
+    weight: 18
     minimumPlayers: 0
   - type: MeteorSwarm
     announcement: station-event-space-dust-start-announcement
@@ -147,7 +147,7 @@
   id: GameRuleMeteorSwarmSmall
   components:
   - type: StationEvent
-    weight: 18
+    weight: 13
     minimumPlayers: 15
   - type: MeteorSwarm
     meteors:
@@ -159,7 +159,7 @@
   id: GameRuleMeteorSwarmMedium
   components:
   - type: StationEvent
-    weight: 10
+    weight: 9
   - type: MeteorSwarm
     meteors:
       MeteorSmall: 3
@@ -171,7 +171,7 @@
   id: GameRuleMeteorSwarmLarge
   components:
   - type: StationEvent
-    weight: 5
+    weight: 3
   - type: MeteorSwarm
     meteors:
       MeteorSmall: 2
@@ -183,7 +183,7 @@
   id: GameRuleUristSwarm
   components:
   - type: StationEvent
-    weight: 0.05
+    weight: 0.01
   - type: MeteorSwarm
     announcement: station-event-meteor-urist-start-announcement
     announcementSound: /Audio/Announcements/attention.ogg

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -99,7 +99,7 @@
   components:
   - type: StationEvent
     startAnnouncement: null # It should be silent.
-    weight: 5 # lower because weird freelance roles
+    weight: 4 # lower because weird freelance roles
     maxOccurrences: 2 # should be the same as [copies] in shuttle_incoming_event.yml
   - type: LoadMapRule
     preloadedGrid: SyndieEvacPod
@@ -159,7 +159,7 @@
   components:
   - type: StationEvent
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
-    weight: 5 # Its just a big ship, so it needs to be rarer to be interesting.
+    weight: 3 # Its just a big ship, so it needs to be rarer to be interesting.
   - type: LoadMapRule
     preloadedGrid: Gym
 
@@ -218,7 +218,7 @@
   components:
   - type: StationEvent
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
-    weight: 11 # this is higher because its just a little generic personal shuttle
+    weight: 7 # this is higher because its just a little generic personal shuttle
     maxOccurrences: 4
   - type: LoadMapRule
     preloadedGrid: Microshuttle


### PR DESCRIPTION
## Описание PR
Rebalansering av händelser för MRP-rollspel genom att öka tiden mellan händelser.
Försök nr 2 för nästa steg baserat på ett accepterat förslag

## Почему / Баланс
Den nuvarande frekvensen av händelser gör MRP-rollspel betydligt svårare. Varje runda förvandlas till en kamp för överlevnad, som kulminerar i en stor antagonistens ankomst. De föreslagna förändringarna kommer att bidra till att öka tiden mellan mellanrundshändelser och något minska frekvensen av stora antagonister samt deras överlappning. Detta skulle göra rundorna mer balanserade och varierade. 

## Технические детали
Ökad sannolikhet för följande händelser:
Strömavbrott, fauna från ventilationen, spridning av kudza. Minskad sannolikhet för: Meteoritregn, Okända rymdskepp, Förlängd tid mellan midround-händelser. Minskad spawnfrekvens för stora antagonister.

## Требования
- [X] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

**Список изменений**
:cl:
- tweak: Ökad sannolikhet för händelser som strömavbrott, framträdande av fauna från ventilationen och spridning av kudza.  
- tweak: Minskad sannolikhet för meteoritregn.  
- tweak: Minskad sannolikhet för att okända rymdskepp ska dyka upp.  
- tweak: Förlängd tid mellan midround-händelser för att förbättra MRP-rollspel och skapa mer utrymme för interaktion.  
- tweak: Minskad frekvens av större antagonistiska händelser för att balansera spelet. 
